### PR TITLE
Frozendict update

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ billiard==3.6.4.0
     # via celery
 celery[redis]==5.2.7
     # via djrs
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   djopenapi
     #   requests
@@ -51,9 +51,9 @@ python-dotenv==0.19.2
     # via djrs
 pytz==2023.3
     # via celery
-redis==4.5.4
+redis==4.5.5
     # via celery
-requests==2.29.0
+requests==2.30.0
     # via djrs
 six==1.16.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,8 +5,6 @@
 #
 #    pip-compile-multi
 #
---trusted-host pypi.org
-
 -e file:.
     # via -r requirements/base.in
 amqp==5.1.1
@@ -37,7 +35,7 @@ click-repl==0.2.0
     # via celery
 djopenapi==0.0.1a1
     # via djrs
-frozendict==2.3.6
+frozendict==2.3.8
     # via djopenapi
 idna==3.4
     # via requests
@@ -51,11 +49,11 @@ python-dateutil==2.7.5
     # via djopenapi
 python-dotenv==0.19.2
     # via djrs
-pytz==2023.2
+pytz==2023.3
     # via celery
-redis==4.5.3
+redis==4.5.4
     # via celery
-requests==2.28.2
+requests==2.29.0
     # via djrs
 six==1.16.0
     # via


### PR DESCRIPTION
### Summary
Running docker compose up in dj-demo folder errored out with:

ERROR: Could not find a version that satisfies the requirement frozendict==2.3.6 (from versions: 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 1.0, 1.2, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.2.0, 2.2.1, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.3.7, 2.3.8)
#0 15.95 ERROR: No matching distribution found for frozendict==2.3.6
#0 16.47 
#0 16.47 [notice] A new release of pip is available: 23.0.1 -> 23.1.2
#0 16.47 [notice] To update, run: pip install --upgrade pip

Seems like frozendict 2.3.6 is no longer available. I ran pip-compile-multi to update the packages in base.txt

### Test Plan

N/A

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

N/A
